### PR TITLE
github runnter has switched to ubuntu 22.04 based on debian bullseye

### DIFF
--- a/.github/workflows/ci-ubuntu-latest.yml
+++ b/.github/workflows/ci-ubuntu-latest.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Add sesam repository key
       run: curl https://download.sep.de/linux/repositories/debian/key.asc | sudo apt-key add -
     - name: Configure sesam apt sources
-      run: echo 'deb https://download.sep.de/linux/repositories/debian/ buster main' | sudo tee -a /etc/apt/sources.list
+      run: echo 'deb https://download.sep.de/linux/repositories/debian/ bullseye main' | sudo tee -a /etc/apt/sources.list
     - name: Update apt sources
       run: sudo apt-get update -y
     - name: Install sesam server


### PR DESCRIPTION
hi,

github action currently fails cause github runner has switched to ubuntu 22.04
which is based on debian/bullseye instead of debian/buster