### PR TITLE
set verify=False for tests to fix ssl error due to self signed certs

### DIFF
--- a/t/tests.py
+++ b/t/tests.py
@@ -8,7 +8,7 @@ cred = {
     "password": "sesam",
 }
 
-api = sepsesam.api.Api(**cred)
+api = sepsesam.api.Api(**cred, verify=False)
 
 
 class TestSepSesam(unittest.TestCase):


### PR DESCRIPTION
New version UI server uses https by default so verify=False need to be set for the tests to work again.