### PR TITLE
Fix wrong parameter name on external_group_create

### DIFF
--- a/src/sepsesam/api.py
+++ b/src/sepsesam/api.py
@@ -1593,14 +1593,12 @@ class Api:
         return data
 
     # Updated to api/v2
-    def external_group_create(self, id, enabled=True, **kwargs):
+    def external_group_create(self, **kwargs):
         """
         Create an external group
         """
         endpoint = "/sep/api/v2/externalgroups/create"
         url = self._urlexpand(endpoint)
-        kwargs["externalId"] = id
-        kwargs["enabled"] = enabled
         response = requests.post(
             url=url,
             auth=(self.username, self.password),

--- a/t/tests.py
+++ b/t/tests.py
@@ -67,7 +67,7 @@ class TestSepSesam(unittest.TestCase):
     def test_externalGroups(self):
         # # external_group_create
         self.assertEqual(
-            api.external_group_create(id="Unittest_ExternalGroup", enabled=True)[
+            api.external_group_create(externalId="Unittest_ExternalGroup", enabled=True)[
                 "externalId"
             ],
             "Unittest_ExternalGroup",


### PR DESCRIPTION
- replace parameter `id` with correct `externalId`